### PR TITLE
chore: release v0.2.2 of markdownlint config

### DIFF
--- a/packages/markdownlint-config/CHANGELOG.md
+++ b/packages/markdownlint-config/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.2 (2023-09-23)
+
+ - docs: fix package name typo in README.md
+
 ## 0.2.1 (2023-09-23)
 
 - fix: configure package to also be compatible with `markdownlint-cli2` v0.10.x (previously was only compatible with v0.8.x, v0.9.x)

--- a/packages/markdownlint-config/README.md
+++ b/packages/markdownlint-config/README.md
@@ -1,4 +1,4 @@
-# markdown-config-neoncitylights
+# markdownlint-config-neoncitylights
 
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg?style=flat-square)](https://opensource.org/licenses/MIT)
 [![npm](https://img.shields.io/npm/v/markdownlint-config-neoncitylights?style=flat-square&logo=npm&logoColor=white)](https://www.npmjs.com/package/markdownlint-config-neoncitylights)
@@ -8,13 +8,13 @@ My personal Markdownlint configuration settings.
 ## Install
 
 ```shell
-npm install markdownlint-cli2 markdown-config-neoncitylights --save-dev
+npm install markdownlint-cli2 markdownlint-config-neoncitylights --save-dev
 ```
 
 Or, if markdownlint is already installed:
 
 ```shell
-npm install markdown-config-neoncitylights --save-dev
+npm install markdownlint-config-neoncitylights --save-dev
 ```
 
 ## License

--- a/packages/markdownlint-config/package.json
+++ b/packages/markdownlint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "markdownlint-config-neoncitylights",
-	"version": "0.2.1",
+	"version": "0.2.2",
 	"description": "Personal Markdownlint configuration settings used by Neoncitylights",
 	"license": "MIT",
 	"author": {


### PR DESCRIPTION
there was a typo in the README :V