### PR TITLE
chore: release new version of all packages

### DIFF
--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -8,6 +8,8 @@
  - ([`a9bd0ad`](https://github.com/neoncitylights/pkg-config/commit/a9bd0addf7c8bbd7dc657040d76176d676f51a73)) deps: upgrade `eslint-plugin-storybook` from 0.6.14 to 0.6.15 (#41)
  - ([`381191c`](https://github.com/neoncitylights/pkg-config/commit/381191cba46647af6d2b51cebbb832ee29abe269)) deps: upgrade `eslint-plugin-testing-library` from 6.0.2 to 6.1.0 (#42)
  - ([`a9bd0ad`](https://github.com/neoncitylights/pkg-config/commit/a9bd0addf7c8bbd7dc657040d76176d676f51a73)) deps: upgrade `eslint-plugin-vitest` from 0.3.1 to 0.3.2 (#41)
+ - ([`603623e`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: fix package metadata for `author.url` and `repository` fields (#38)
+ - ([`05cf9e9`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: update references to old repository name (#35)
 
 ## 0.2.0 (2023-08-28)
 

--- a/packages/eslint-config/CHANGELOG.md
+++ b/packages/eslint-config/CHANGELOG.md
@@ -1,12 +1,21 @@
 # Changelog
 
+## 0.3.0 (2023-10-19)
+
+ - ([`a9bd0ad`](https://github.com/neoncitylights/pkg-config/commit/a9bd0addf7c8bbd7dc657040d76176d676f51a73)) deps: upgrade `eslint` from 8.50.0 to 8.51.0 (#41)
+ - ([`de00d57`](https://github.com/neoncitylights/pkg-config/commit/de00d57240795ce068cff305603ea412cd6b566b), [`a9bd0ad`](https://github.com/neoncitylights/pkg-config/commit/a9bd0addf7c8bbd7dc657040d76176d676f51a73), [`381191c`](https://github.com/neoncitylights/pkg-config/commit/381191cba46647af6d2b51cebbb832ee29abe269)) deps: upgrade `@typescript-eslint/eslint-plugin` from 6.7.2 to 6.7.5 (#39, #41, #42)
+ - ([`de00d57`](https://github.com/neoncitylights/pkg-config/commit/de00d57240795ce068cff305603ea412cd6b566b), [`a9bd0ad`](https://github.com/neoncitylights/pkg-config/commit/a9bd0addf7c8bbd7dc657040d76176d676f51a73), [`381191c`](https://github.com/neoncitylights/pkg-config/commit/381191cba46647af6d2b51cebbb832ee29abe269)) deps: upgrade `@typescript-eslint/parser` from 6.7.2 to 6.7.5 (#39, #41, #42)
+ - ([`a9bd0ad`](https://github.com/neoncitylights/pkg-config/commit/a9bd0addf7c8bbd7dc657040d76176d676f51a73)) deps: upgrade `eslint-plugin-storybook` from 0.6.14 to 0.6.15 (#41)
+ - ([`381191c`](https://github.com/neoncitylights/pkg-config/commit/381191cba46647af6d2b51cebbb832ee29abe269)) deps: upgrade `eslint-plugin-testing-library` from 6.0.2 to 6.1.0 (#42)
+ - ([`a9bd0ad`](https://github.com/neoncitylights/pkg-config/commit/a9bd0addf7c8bbd7dc657040d76176d676f51a73)) deps: upgrade `eslint-plugin-vitest` from 0.3.1 to 0.3.2 (#41)
+
 ## 0.2.0 (2023-08-28)
 
- - ([4c068da](https://github.com/neoncitylights/pkg-config/commit/4c068daaf191e274ca44b8037a1725e4e450c452)) deps: upgrade `eslint-plugin-testing-library` from 6.0.0 to 6.0.1
- - ([4c068da](https://github.com/neoncitylights/pkg-config/commit/4c068daaf191e274ca44b8037a1725e4e450c452)) deps: upgrade `eslint-plugin-playwright` from 0.15.3 to 0.16.0
- - ([72ac0ea](https://github.com/neoncitylights/pkg-config/commit/72ac0ea329772b02ef02ba21c48904588c48b849)) deps: upgrade `eslint-plugin-react` from 7.33.1 to 7.33.2
- - ([72ac0ea](https://github.com/neoncitylights/pkg-config/commit/72ac0ea329772b02ef02ba21c48904588c48b849)) deps: upgrade `@typescript-eslint/parser` from 6.3.0 to 6.4.1 
- - ([72ac0ea](https://github.com/neoncitylights/pkg-config/commit/72ac0ea329772b02ef02ba21c48904588c48b849)) deps: upgrade `@typescript-eslint/eslint-plugin` from 6.3.0 to 6.4.1
+ - ([`4c068da`](https://github.com/neoncitylights/pkg-config/commit/4c068daaf191e274ca44b8037a1725e4e450c452)) deps: upgrade `eslint-plugin-testing-library` from 6.0.0 to 6.0.1
+ - ([`4c068da`](https://github.com/neoncitylights/pkg-config/commit/4c068daaf191e274ca44b8037a1725e4e450c452)) deps: upgrade `eslint-plugin-playwright` from 0.15.3 to 0.16.0
+ - ([`72ac0ea`](https://github.com/neoncitylights/pkg-config/commit/72ac0ea329772b02ef02ba21c48904588c48b849)) deps: upgrade `eslint-plugin-react` from 7.33.1 to 7.33.2
+ - ([`72ac0ea`](https://github.com/neoncitylights/pkg-config/commit/72ac0ea329772b02ef02ba21c48904588c48b849)) deps: upgrade `@typescript-eslint/parser` from 6.3.0 to 6.4.1 
+ - ([`72ac0ea`](https://github.com/neoncitylights/pkg-config/commit/72ac0ea329772b02ef02ba21c48904588c48b849)) deps: upgrade `@typescript-eslint/eslint-plugin` from 6.3.0 to 6.4.1
 
 ## 0.1.0 (2023-08-14)
 

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "eslint-config-neoncitylights",
-	"version": "0.2.0",
+	"version": "0.3.0",
 	"description": "Personal ESLint configuration settings used by Neoncitylights",
 	"license": "MIT",
 	"author": {

--- a/packages/markdownlint-config/CHANGELOG.md
+++ b/packages/markdownlint-config/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.3 (2023-10-19)
+
+ - ([`603623e`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: fix package metadata for `author.url` and `repository` fields (#38)
+ - ([`05cf9e9`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: update references to old repository name (#35)
+
 ## 0.2.2 (2023-09-23)
 
  - docs: fix package name typo in README.md

--- a/packages/markdownlint-config/package.json
+++ b/packages/markdownlint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "markdownlint-config-neoncitylights",
-	"version": "0.2.2",
+	"version": "0.2.3",
 	"description": "Personal Markdownlint configuration settings used by Neoncitylights",
 	"license": "MIT",
 	"author": {

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Changelog
 
-## 0.2.1 (2023-10-19)
+## 0.3.0 (2023-10-19)
 
+ - ([`5e7242d`](https://github.com/neoncitylights/pkg-config/commit/5e7242dd2bb54eb7772f798f01c7b590f80ca1ca)) chore: bump `stylelint-config-standard-scss` from 10.0.0 to 11.0.0 (#20)
  - ([`603623e`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: fix package metadata for `author.url` and `repository` fields (#38)
  - ([`05cf9e9`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: update references to old repository name (#35)
 

--- a/packages/stylelint-config/CHANGELOG.md
+++ b/packages/stylelint-config/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1 (2023-10-19)
+
+ - ([`603623e`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: fix package metadata for `author.url` and `repository` fields (#38)
+ - ([`05cf9e9`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: update references to old repository name (#35)
+
 ## 0.2.0 (2023-08-28)
 
  - ([e96babc](https://github.com/neoncitylights/pkg-config/commit/e96babceac23edfa935544fd93ec9bb01745c2cb)) deps: upgrade `stylelint` from 15.10.2 to 15.10.3

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "stylelint-config-neoncitylights",
-	"version": "0.2.0",
+	"version": "0.2.1",
 	"description": "Personal Stylelint configuration settings used by Neoncitylights",
 	"license": "MIT",
 	"author": {

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "stylelint-config-neoncitylights",
-	"version": "0.2.1",
+	"version": "0.3.0",
 	"description": "Personal Stylelint configuration settings used by Neoncitylights",
 	"license": "MIT",
 	"author": {

--- a/packages/tsconfig/CHANGELOG.md
+++ b/packages/tsconfig/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.0.2 (2023-10-19)
+
+ - ([`603623e`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: fix package metadata for `author.url` and `repository` fields (#38)
+ - ([`05cf9e9`](https://github.com/neoncitylights/pkg-config/commit/603623e0b4c60f35558fbdda4aa1ff2b2221d77b)) chore: update references to old repository name (#35)
+
 ## 0.0.1 (2023-09-16)
 
  - Enabled [`compilerOptions.resolveJsonModule`](https://www.typescriptlang.org/tsconfig#resolveJsonModule)

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "tsconfig-neoncitylights",
-	"version": "0.0.1",
+	"version": "0.0.2",
 	"description": "Personal TypeScript configuration settings used by Neoncitylights",
 	"license": "MIT",
 	"author": {


### PR DESCRIPTION
- bump `eslint-config-neoncitylights` from 0.2.0 to 0.3.0
- bump `stylelint-config-neoncitylights` from 0.2.0 to 0.3.0
- bump `tsconfig-neoncitylights` from 0.0.1 to 0.0.2
- bump `markdownlint-config-neoncitylights` from 0.2.2 to 0.2.3