### PR TITLE
chore(eslint): provide better defaults for react config

### DIFF
--- a/packages/eslint-config/react.json
+++ b/packages/eslint-config/react.json
@@ -1,9 +1,15 @@
 {
+	"settings": {
+		"react": {
+			"version": "detect"
+		}
+	},
 	"extends": [
 		"plugin:jsx-a11y/recommended",
 		"plugin:react/recommended",
 		"plugin:react/jsx-runtime",
 		"plugin:react-hooks/recommended",
-		"plugin:storybook/recommended"
+		"plugin:storybook/recommended",
+		"plugin:testing-library/react"
 	]
 }

--- a/packages/eslint-config/tests.json
+++ b/packages/eslint-config/tests.json
@@ -1,7 +1,6 @@
 {
 	"extends": [
 		"plugin:vitest/recommended",
-		"plugin:playwright/recommended",
-		"plugin:testing-library/react"
+		"plugin:playwright/recommended"
 	]
 }


### PR DESCRIPTION
- moves `eslint-plugin-testing-library/react` from `tests` config to `react` config
- auto-detect React version for `eslint-plugin-react`