### PR TITLE
ci(perf): ensure publint only runs when needed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,12 +46,6 @@ jobs:
               node --version
               npm --version
               npm run lint:md-env
-          - tool: publint
-            npm-cmd-suffix: pub
-            env-cmd: |
-              node --version
-              npm --version
-              npm run lint:pub-env
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -34,7 +34,7 @@
 	],
 	"scripts": {
 		"publint": "publint .",
-		"prepublish": "npm run publint"
+		"prepublishOnly": "npm run publint"
 	},
 	"peerDependencies": {
 		"eslint": "^8.x"

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -33,7 +33,8 @@
 		"typescript.json"
 	],
 	"scripts": {
-		"publint": "publint ."
+		"publint": "publint .",
+		"prepublish": "npm run publint"
 	},
 	"peerDependencies": {
 		"eslint": "^8.x"

--- a/packages/markdownlint-config/package.json
+++ b/packages/markdownlint-config/package.json
@@ -31,7 +31,7 @@
 	],
 	"scripts": {
 		"publint": "publint .",
-		"prepublish": "npm run publint"
+		"prepublishOnly": "npm run publint"
 	},
 	"peerDependencies": {
 		"markdownlint-cli2": ">= 0.10.0"

--- a/packages/markdownlint-config/package.json
+++ b/packages/markdownlint-config/package.json
@@ -30,7 +30,8 @@
 		"mdbook.json"
 	],
 	"scripts": {
-		"publint": "publint ."
+		"publint": "publint .",
+		"prepublish": "npm run publint"
 	},
 	"peerDependencies": {
 		"markdownlint-cli2": ">= 0.10.0"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -34,7 +34,7 @@
 	],
 	"scripts": {
 		"publint": "publint .",
-		"prepublish": "npm run publint"
+		"prepublishOnly": "npm run publint"
 	},
 	"peerDependencies": {
 		"stylelint": "^15.x || ^16.x"

--- a/packages/stylelint-config/package.json
+++ b/packages/stylelint-config/package.json
@@ -33,7 +33,8 @@
 		"properties.json"
 	],
 	"scripts": {
-		"publint": "publint ."
+		"publint": "publint .",
+		"prepublish": "npm run publint"
 	},
 	"peerDependencies": {
 		"stylelint": "^15.x || ^16.x"

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -31,6 +31,6 @@
 	],
 	"scripts": {
 		"publint": "publint .",
-		"prepublish": "npm run publint"
+		"prepublishOnly": "npm run publint"
 	}
 }

--- a/packages/tsconfig/package.json
+++ b/packages/tsconfig/package.json
@@ -30,6 +30,7 @@
 		"tsconfig.react.json"
 	],
 	"scripts": {
-		"publint": "publint ."
+		"publint": "publint .",
+		"prepublish": "npm run publint"
 	}
 }


### PR DESCRIPTION
Currently, the CI `lint` job will run all lint tools 4 times correctly (since there's 4 packages). The `publint` tool however, is ran 16 times, since the root package.json has set it to run the command in all workspaces.

This command removes `publint` from the `lint` job matrix, and has it run through the `pkg-is-publishable` job through NPM's lifecycle scripts, `prepublish`.